### PR TITLE
fix: correct typo in Neuron.py and README.md

### DIFF
--- a/Neural/Neuron.py
+++ b/Neural/Neuron.py
@@ -3,10 +3,10 @@
 
 """
 ====================================================================================================
-Quantum-Enhanced Language Model (QELM) - Nueron
+Quantum-Enhanced Language Model (QELM) - Neuron
 ====================================================================================================
 
-This script defines a comprehensive Quantum-Enhanced Language Model (QELM) - Nueron (Beta) leveraging Qiskit.
+This script defines a comprehensive Quantum-Enhanced Language Model (QELM) - Neuron (Beta) leveraging Qiskit.
 It incorporates advanced quantum techniques such as logical qubits with error correction,
 graphene-like layer structures, and scalable neural network architectures inspired by string theory
 and brain-like connectivity. The model is designed to simulate large-scale quantum neural networks
@@ -92,7 +92,7 @@ def normalize_vector(vec: np.ndarray) -> np.ndarray:
     return vec / norm
 
 # ============================
-# Quantum Neuron (20-Qubit Logical Unit) *If changing, stay below 100 or degredation occurs.
+# Quantum Neuron (20-Qubit Logical Unit) *If changing, stay below 100 or degradation occurs.
 # ============================
 
 class QuantumNeuron:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - **New noise mitigation options**: support for **Pauli twirling** and **zero‑noise extrapolation (ZNE)**. Pauli twirling randomly applies Pauli gates to transform complicated noise into a simpler stochastic channel:contentReference[oaicite:0]{index=0}, while zero‑noise extrapolation runs circuits at multiple noise levels and extrapolates to the zero‑noise result:contentReference[oaicite:1]{index=1}. These options can be toggled via the GUI or CLI, and ZNE scaling factors are user configurable.
 
 **QELM Quantum** (Connect to IBM quantum computers) *Last update 12/21/2024*  
-- Must have an IBM account (Free account alots 10 minutes per month)  
+- Must have an IBM account (Free account allots 10 minutes per month)  
 - Must have a basic understanding of running circuits  
 - Must be familiar with Quantum Computers (you can switch, but I usually use Brisbane for free)
 - 8/2/2025 - Qelm now has a drop in for backends. Future releases of Qelm will automatically have this feature. Quantum has been retired but still works perfectly.


### PR DESCRIPTION
## Summary
**Fix minor typos**
- Nueron -> Neuron
- alots -> allots