### PR TITLE
Build hardened single-file Windows QELM executable

### DIFF
--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -1,0 +1,105 @@
+name: Windows executable
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          architecture: x64
+          cache: pip
+
+      - name: Install Python packages
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install --no-deps .
+          python -m pip install pyinstaller pillow pytest
+
+      - name: Prepare bundled data
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force build | Out-Null
+          python -m nltk.downloader -d build/nltk_data punkt punkt_tab stopwords
+          python -c "from PIL import Image; im=Image.open('docs/images/qelm_logo_small.png').convert('RGBA'); im.save('build/qelm.ico', sizes=[(16,16),(24,24),(32,32),(48,48),(64,64),(128,128),(256,256)])"
+          choco install graphviz -y --no-progress
+          $dot = Get-ChildItem 'C:\Program Files\Graphviz' -Recurse -Filter dot.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $dot) { throw 'Graphviz dot.exe was not found' }
+          $graphvizBin = $dot.Directory.FullName
+          New-Item -ItemType Directory -Force build/graphviz/bin | Out-Null
+          Copy-Item "$graphvizBin/*" build/graphviz/bin -Recurse -Force
+          Get-ChildItem build/graphviz/bin -File | Where-Object { $_.Name -match '^(tcl|tk)86.*\.dll$' } | Remove-Item -Force
+
+      - name: Test source
+        shell: pwsh
+        run: |
+          python -m compileall -q Qelm2.py QELMChatUI.py QelmInference.py QelmTokenizer.py qelm_exe.py qelm
+          pytest -q
+
+      - name: Build QELM
+        shell: pwsh
+        run: pyinstaller --noconfirm --clean QELM.spec
+
+      - name: Test executable dataset preparation
+        shell: pwsh
+        run: |
+          Set-Content -Path build/smoke.txt -Value 'QELM executable smoke test'
+          $inputPath = (Resolve-Path build/smoke.txt).Path
+          $outputPath = Join-Path $PWD 'build/smoke.u16'
+          $process = Start-Process -FilePath dist/QELM/QELM.exe -ArgumentList '--qelm_prep_tokens','--input',$inputPath,'--output',$outputPath -PassThru
+          if (-not $process.WaitForExit(120000)) {
+            Stop-Process -Id $process.Id -Force
+            throw 'QELM dataset preparation timed out'
+          }
+          if ($process.ExitCode -ne 0) { throw "QELM dataset preparation exited with $($process.ExitCode)" }
+          if (-not (Test-Path build/smoke.u16)) { throw 'QELM did not create the token file' }
+          if ((Get-Item build/smoke.u16).Length -lt 2) { throw 'QELM created an empty token file' }
+
+      - name: Test executable startup
+        shell: pwsh
+        run: |
+          $process = Start-Process -FilePath dist/QELM/QELM.exe -ArgumentList '--qelm_exe_smoke' -PassThru
+          if (-not $process.WaitForExit(180000)) {
+            Stop-Process -Id $process.Id -Force
+            if (Test-Path dist/QELM/qelm_startup_error.txt) { Get-Content dist/QELM/qelm_startup_error.txt }
+            if (Test-Path dist/QELM/qelm_crashlog.txt) { Get-Content dist/QELM/qelm_crashlog.txt }
+            throw 'QELM startup test timed out'
+          }
+          if ($process.ExitCode -ne 0) {
+            if (Test-Path dist/QELM/qelm_startup_error.txt) { Get-Content dist/QELM/qelm_startup_error.txt }
+            if (Test-Path dist/QELM/qelm_crashlog.txt) { Get-Content dist/QELM/qelm_crashlog.txt }
+            throw "QELM startup test exited with $($process.ExitCode)"
+          }
+          if (-not (Test-Path dist/QELM/qelm_exe_smoke.ok)) { throw 'QELM did not finish its startup test' }
+          Remove-Item dist/QELM/qelm_exe_smoke.ok -Force
+
+      - name: Package executable
+        shell: pwsh
+        run: |
+          @'
+          @echo off
+          start "" "%~dp0QELM.exe"
+          '@ | Set-Content -Path dist/QELM/START_QELM.bat
+          tar.exe -a -c -f dist/QELM-Windows-x64.zip -C dist QELM
+          Get-FileHash dist/QELM-Windows-x64.zip -Algorithm SHA256 | Format-List
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: QELM-Windows-x64
+          path: dist/QELM-Windows-x64.zip
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -3,15 +3,29 @@ name: Windows single-file executable
 on:
   pull_request:
     branches: [main]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      sign_release:
+        description: Sign and timestamp QELM.exe with Microsoft Artifact Signing
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:
     runs-on: windows-latest
     timeout-minutes: 120
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ARTIFACT_SIGNING_ENDPOINT: ${{ vars.ARTIFACT_SIGNING_ENDPOINT }}
+      ARTIFACT_SIGNING_ACCOUNT: ${{ vars.ARTIFACT_SIGNING_ACCOUNT }}
+      ARTIFACT_SIGNING_PROFILE: ${{ vars.ARTIFACT_SIGNING_PROFILE }}
 
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +71,7 @@ jobs:
         shell: pwsh
         run: pyinstaller --noconfirm --clean QELM.spec
 
-      - name: Verify single-file output
+      - name: Verify single-file output and Windows identity
         shell: pwsh
         run: |
           $files = @(Get-ChildItem dist -File)
@@ -66,7 +80,67 @@ jobs:
           if ($files.Count -ne 1 -or $files[0].Name -ne 'QELM.exe') {
             throw "Expected only dist/QELM.exe, found: $($files.Name -join ', ')"
           }
-          Get-Item dist/QELM.exe | Format-List Name,Length,FullName
+          $item = Get-Item dist/QELM.exe
+          $info = $item.VersionInfo
+          if ($info.CompanyName -ne 'R&D BioTech Alaska Inc.') { throw "Missing or incorrect CompanyName: $($info.CompanyName)" }
+          if ($info.ProductName -ne 'QELM') { throw "Missing or incorrect ProductName: $($info.ProductName)" }
+          if ($info.OriginalFilename -ne 'QELM.exe') { throw "Missing or incorrect OriginalFilename: $($info.OriginalFilename)" }
+          $item | Format-List Name,Length,FullName
+          $info | Format-List CompanyName,FileDescription,FileVersion,ProductName,ProductVersion,OriginalFilename
+
+      - name: Require release signing configuration
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_release }}
+        shell: pwsh
+        run: |
+          $required = @(
+            'AZURE_CLIENT_ID',
+            'AZURE_TENANT_ID',
+            'AZURE_SUBSCRIPTION_ID',
+            'ARTIFACT_SIGNING_ENDPOINT',
+            'ARTIFACT_SIGNING_ACCOUNT',
+            'ARTIFACT_SIGNING_PROFILE'
+          )
+          $missing = @($required | Where-Object { [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_)) })
+          if ($missing.Count -gt 0) {
+            throw "Signed release requested, but these GitHub secrets or variables are missing: $($missing -join ', ')"
+          }
+
+      - name: Sign in to Azure with GitHub OIDC
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_release }}
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Authenticode sign and timestamp QELM.exe
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_release }}
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.ARTIFACT_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.ARTIFACT_SIGNING_PROFILE }}
+          files: ${{ github.workspace }}\dist\QELM.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: QELM - Quantum Enhanced Language Model
+          description-url: https://github.com/R-D-BioTech-Alaska/Qelm
+
+      - name: Verify Authenticode signature
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_release }}
+        shell: pwsh
+        run: |
+          $signature = Get-AuthenticodeSignature dist/QELM.exe
+          $signature | Format-List Status,StatusMessage,SignerCertificate,TimeStamperCertificate
+          if ($signature.Status -ne 'Valid') { throw "QELM.exe signature is not valid: $($signature.StatusMessage)" }
+          $signTool = Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\bin' -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1
+          if (-not $signTool) { throw 'SignTool was not found on the Windows runner.' }
+          & $signTool.FullName verify /pa /all /v dist/QELM.exe
+          if ($LASTEXITCODE -ne 0) { throw "SignTool verification failed with exit code $LASTEXITCODE" }
 
       - name: Test executable dataset preparation
         shell: pwsh
@@ -103,6 +177,29 @@ jobs:
           if (-not (Test-Path build/qelm_exe_smoke.ok)) { throw 'QELM did not finish its startup test' }
           Remove-Item build/qelm_exe_smoke.ok -Force
 
+      - name: Scan executable with Microsoft Defender
+        shell: pwsh
+        run: |
+          $platformRoot = Join-Path $env:ProgramData 'Microsoft\Windows Defender\Platform'
+          $mpCmd = $null
+          if (Test-Path $platformRoot) {
+            $mpCmd = Get-ChildItem $platformRoot -Recurse -Filter MpCmdRun.exe -ErrorAction SilentlyContinue |
+              Sort-Object FullName -Descending |
+              Select-Object -First 1
+          }
+          if (-not $mpCmd) {
+            $fallback = Join-Path $env:ProgramFiles 'Windows Defender\MpCmdRun.exe'
+            if (Test-Path $fallback) { $mpCmd = Get-Item $fallback }
+          }
+          if (-not $mpCmd) {
+            Write-Warning 'Microsoft Defender command-line scanner is unavailable on this runner.'
+          } else {
+            & $mpCmd.FullName -SignatureUpdate
+            & $mpCmd.FullName -Scan -ScanType 3 -File (Resolve-Path dist/QELM.exe).Path -DisableRemediation
+            if ($LASTEXITCODE -eq 2) { throw 'Microsoft Defender detected QELM.exe as a threat.' }
+            if ($LASTEXITCODE -ne 0) { Write-Warning "Microsoft Defender scan returned non-detection error code $LASTEXITCODE." }
+          }
+
       - name: Checksum executable
         shell: pwsh
         run: |
@@ -110,7 +207,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: QELM-Single-EXE-Windows-x64
+          name: ${{ github.event_name == 'workflow_dispatch' && inputs.sign_release && 'QELM-Signed-Windows-x64' || 'QELM-Unsigned-CI-Windows-x64' }}
           path: dist/QELM.exe
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -1,4 +1,4 @@
-name: Windows executable
+name: Windows single-file executable
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build:
     runs-on: windows-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
           python -m pip install --no-deps .
           python -m pip install pyinstaller pillow pytest
 
-      - name: Prepare bundled data
+      - name: Prepare embedded data
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force build | Out-Null
@@ -50,9 +50,20 @@ jobs:
           python -m compileall -q Qelm2.py QELMChatUI.py QelmInference.py QelmTokenizer.py qelm_exe.py qelm
           pytest -q
 
-      - name: Build QELM
+      - name: Build single QELM executable
         shell: pwsh
         run: pyinstaller --noconfirm --clean QELM.spec
+
+      - name: Verify single-file output
+        shell: pwsh
+        run: |
+          $files = @(Get-ChildItem dist -File)
+          $directories = @(Get-ChildItem dist -Directory)
+          if ($directories.Count -ne 0) { throw 'The build produced a directory; QELM must be one executable.' }
+          if ($files.Count -ne 1 -or $files[0].Name -ne 'QELM.exe') {
+            throw "Expected only dist/QELM.exe, found: $($files.Name -join ', ')"
+          }
+          Get-Item dist/QELM.exe | Format-List Name,Length,FullName
 
       - name: Test executable dataset preparation
         shell: pwsh
@@ -60,8 +71,9 @@ jobs:
           Set-Content -Path build/smoke.txt -Value 'QELM executable smoke test'
           $inputPath = (Resolve-Path build/smoke.txt).Path
           $outputPath = Join-Path $PWD 'build/smoke.u16'
-          $process = Start-Process -FilePath dist/QELM/QELM.exe -ArgumentList '--qelm_prep_tokens','--input',$inputPath,'--output',$outputPath -PassThru
-          if (-not $process.WaitForExit(120000)) {
+          $env:QELM_OUTPUT_DIR = (Resolve-Path build).Path
+          $process = Start-Process -FilePath dist/QELM.exe -ArgumentList '--qelm_prep_tokens','--input',$inputPath,'--output',$outputPath -PassThru
+          if (-not $process.WaitForExit(300000)) {
             Stop-Process -Id $process.Id -Force
             throw 'QELM dataset preparation timed out'
           }
@@ -72,34 +84,31 @@ jobs:
       - name: Test executable startup
         shell: pwsh
         run: |
-          $process = Start-Process -FilePath dist/QELM/QELM.exe -ArgumentList '--qelm_exe_smoke' -PassThru
-          if (-not $process.WaitForExit(180000)) {
+          $env:QELM_OUTPUT_DIR = (Resolve-Path build).Path
+          $process = Start-Process -FilePath dist/QELM.exe -ArgumentList '--qelm_exe_smoke' -PassThru
+          if (-not $process.WaitForExit(600000)) {
             Stop-Process -Id $process.Id -Force
-            if (Test-Path dist/QELM/qelm_startup_error.txt) { Get-Content dist/QELM/qelm_startup_error.txt }
-            if (Test-Path dist/QELM/qelm_crashlog.txt) { Get-Content dist/QELM/qelm_crashlog.txt }
+            if (Test-Path build/qelm_startup_error.txt) { Get-Content build/qelm_startup_error.txt }
+            if (Test-Path build/qelm_crashlog.txt) { Get-Content build/qelm_crashlog.txt }
             throw 'QELM startup test timed out'
           }
           if ($process.ExitCode -ne 0) {
-            if (Test-Path dist/QELM/qelm_startup_error.txt) { Get-Content dist/QELM/qelm_startup_error.txt }
-            if (Test-Path dist/QELM/qelm_crashlog.txt) { Get-Content dist/QELM/qelm_crashlog.txt }
+            if (Test-Path build/qelm_startup_error.txt) { Get-Content build/qelm_startup_error.txt }
+            if (Test-Path build/qelm_crashlog.txt) { Get-Content build/qelm_crashlog.txt }
             throw "QELM startup test exited with $($process.ExitCode)"
           }
-          if (-not (Test-Path dist/QELM/qelm_exe_smoke.ok)) { throw 'QELM did not finish its startup test' }
-          Remove-Item dist/QELM/qelm_exe_smoke.ok -Force
+          if (-not (Test-Path build/qelm_exe_smoke.ok)) { throw 'QELM did not finish its startup test' }
+          Remove-Item build/qelm_exe_smoke.ok -Force
 
-      - name: Package executable
+      - name: Checksum executable
         shell: pwsh
         run: |
-          @'
-          @echo off
-          start "" "%~dp0QELM.exe"
-          '@ | Set-Content -Path dist/QELM/START_QELM.bat
-          tar.exe -a -c -f dist/QELM-Windows-x64.zip -C dist QELM
-          Get-FileHash dist/QELM-Windows-x64.zip -Algorithm SHA256 | Format-List
+          Get-FileHash dist/QELM.exe -Algorithm SHA256 | Format-List
 
       - uses: actions/upload-artifact@v4
         with:
-          name: QELM-Windows-x64
-          path: dist/QELM-Windows-x64.zip
+          name: QELM-Single-EXE-Windows-x64
+          path: dist/QELM.exe
           if-no-files-found: error
           retention-days: 30
+          compression-level: 0

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -35,6 +35,9 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force build | Out-Null
           python -m nltk.downloader -d build/nltk_data punkt punkt_tab stopwords
+          Remove-Item build/nltk_data/tokenizers/punkt.zip -Force -ErrorAction SilentlyContinue
+          Remove-Item build/nltk_data/tokenizers/punkt_tab.zip -Force -ErrorAction SilentlyContinue
+          Remove-Item build/nltk_data/corpora/stopwords.zip -Force -ErrorAction SilentlyContinue
           python -c "from PIL import Image; im=Image.open('docs/images/qelm_logo_small.png').convert('RGBA'); im.save('build/qelm.ico', sizes=[(16,16),(24,24),(32,32),(48,48),(64,64),(128,128),(256,256)])"
           choco install graphviz -y --no-progress
           $dot = Get-ChildItem 'C:\Program Files\Graphviz' -Recurse -Filter dot.exe -ErrorAction SilentlyContinue | Select-Object -First 1

--- a/QELM.manifest
+++ b/QELM.manifest
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    type="win32"
+    name="RDBioTechAlaska.QELM"
+    version="1.0.0.0"
+    processorArchitecture="amd64" />
+  <description>QELM - Quantum Enhanced Language Model</description>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/QELM.spec
+++ b/QELM.spec
@@ -81,6 +81,8 @@ exe = EXE(
     upx=False,
     console=False,
     icon=str(root / 'build' / 'qelm.ico'),
+    version=str(root / 'QELM.version'),
+    manifest=str(root / 'QELM.manifest'),
     runtime_tmpdir=None,
     append_pkg=True,
 )

--- a/QELM.spec
+++ b/QELM.spec
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_all, copy_metadata
+
+
+root = Path(SPECPATH)
+datas = [
+    (str(root / 'QLM'), 'QLM'),
+    (str(root / 'Datasets'), 'Datasets'),
+    (str(root / 'docs' / 'images' / 'qelm_logo_small.png'), 'docs/images'),
+    (str(root / 'build' / 'nltk_data'), 'nltk_data'),
+    (str(root / 'build' / 'graphviz'), 'graphviz'),
+    (str(root / 'README.md'), '.'),
+    (str(root / 'LICENSE'), '.'),
+    (str(root / 'requirements.txt'), '.'),
+]
+binaries = []
+hiddenimports = [
+    'Qelm2',
+    'QelmInference',
+    'QelmTokenizer',
+    'QELMChatUI',
+]
+
+for package in ('qiskit', 'qiskit_aer', 'qiskit_ibm_runtime'):
+    try:
+        package_data, package_binaries, package_hidden = collect_all(package)
+        datas += package_data
+        binaries += package_binaries
+        hiddenimports += package_hidden
+    except Exception:
+        pass
+
+for package in (
+    'qelm',
+    'qiskit',
+    'qiskit-aer',
+    'qiskit-ibm-runtime',
+    'numpy',
+    'scipy',
+    'nltk',
+    'tensorflow',
+    'keras',
+    'psutil',
+    'matplotlib',
+    'pydot',
+    'graphviz',
+):
+    try:
+        datas += copy_metadata(package)
+    except Exception:
+        pass
+
+analysis = Analysis(
+    ['qelm_exe.py'],
+    pathex=[str(root)],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=['torch', 'transformers', 'llama_cpp', 'gguf'],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(analysis.pure)
+
+exe = EXE(
+    pyz,
+    analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name='QELM',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    icon=str(root / 'build' / 'qelm.ico'),
+    contents_directory='.',
+)
+
+bundle = COLLECT(
+    exe,
+    analysis.binaries,
+    analysis.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name='QELM',
+)

--- a/QELM.spec
+++ b/QELM.spec
@@ -70,8 +70,10 @@ pyz = PYZ(analysis.pure)
 exe = EXE(
     pyz,
     analysis.scripts,
+    analysis.binaries,
+    analysis.datas,
     [],
-    exclude_binaries=True,
+    exclude_binaries=False,
     name='QELM',
     debug=False,
     bootloader_ignore_signals=False,
@@ -79,15 +81,6 @@ exe = EXE(
     upx=False,
     console=False,
     icon=str(root / 'build' / 'qelm.ico'),
-    contents_directory='.',
-)
-
-bundle = COLLECT(
-    exe,
-    analysis.binaries,
-    analysis.datas,
-    strip=False,
-    upx=False,
-    upx_exclude=[],
-    name='QELM',
+    runtime_tmpdir=None,
+    append_pkg=True,
 )

--- a/QELM.version
+++ b/QELM.version
@@ -1,0 +1,32 @@
+VSVersionInfo(
+    ffi=FixedFileInfo(
+        filevers=(1, 0, 0, 0),
+        prodvers=(1, 0, 0, 0),
+        mask=0x3F,
+        flags=0x0,
+        OS=0x40004,
+        fileType=0x1,
+        subtype=0x0,
+        date=(0, 0),
+    ),
+    kids=[
+        StringFileInfo(
+            [
+                StringTable(
+                    '040904B0',
+                    [
+                        StringStruct('CompanyName', 'R&D BioTech Alaska Inc.'),
+                        StringStruct('FileDescription', 'QELM - Quantum Enhanced Language Model'),
+                        StringStruct('FileVersion', '1.0.0.0'),
+                        StringStruct('InternalName', 'QELM'),
+                        StringStruct('LegalCopyright', 'Copyright (c) 2024-2026 R&D BioTech Alaska Inc.'),
+                        StringStruct('OriginalFilename', 'QELM.exe'),
+                        StringStruct('ProductName', 'QELM'),
+                        StringStruct('ProductVersion', '1.0.0.0'),
+                    ],
+                )
+            ]
+        ),
+        VarFileInfo([VarStruct('Translation', [1033, 1200])]),
+    ],
+)

--- a/Qelm2.py
+++ b/Qelm2.py
@@ -364,6 +364,14 @@ def _clone_model_for_worker(src_model):
 
 import sys, json, time, logging, traceback, threading, multiprocessing, concurrent.futures, queue, subprocess, pickle
 import itertools
+
+
+def _qelm_python_command(*args):
+    if getattr(sys, 'frozen', False):
+        return [sys.executable, *args]
+    return [sys.executable, os.path.abspath(__file__), *args]
+
+
 from collections import defaultdict, Counter
 from typing import List, Dict, Tuple, Optional, Callable, Union
 from dataclasses import dataclass
@@ -6556,7 +6564,7 @@ def load_real_dataset(
         else:
             progress_callback(0.20, "Encoding dataset via isolated subprocess (Windows-stable)...")
             import subprocess, sys, json
-            cmd = [sys.executable, os.path.abspath(__file__), '--qelm_prep_tokens', '--input', file_path, '--output', tokens_path]
+            cmd = _qelm_python_command('--qelm_prep_tokens', '--input', file_path, '--output', tokens_path)
             p = subprocess.run(cmd, capture_output=True, text=True)
             if p.returncode != 0:
                 msg = (p.stderr or p.stdout or '').strip()
@@ -6788,14 +6796,13 @@ def load_hf_dataset(
         progress_callback(0.25, f"Reusing cached HF tokens: {os.path.basename(tokens_path)}")
     else:
         progress_callback(0.10, f"Preparing Hugging Face dataset via subprocess: {ds} [{cfg or 'default'}] split={sp} col={col}")
-        cmd = [
-            sys.executable, os.path.abspath(__file__),
+        cmd = _qelm_python_command(
             '--qelm_prep_hf',
             '--dataset', ds,
             '--split', sp,
             '--text_column', col,
             '--output', tokens_path,
-        ]
+        )
         if cfg:
             cmd += ['--config', cfg]
         if int(max_examples) > 0:

--- a/qelm_exe.py
+++ b/qelm_exe.py
@@ -1,0 +1,82 @@
+import multiprocessing
+import os
+import sys
+import traceback
+
+
+def _app_dir():
+    if getattr(sys, 'frozen', False):
+        return os.path.dirname(sys.executable)
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+def _prepare_runtime():
+    root = _app_dir()
+    os.chdir(root)
+    os.environ.setdefault('QELM_LAZY_NATIVE_IMPORTS', '1')
+    os.environ.setdefault('TF_ENABLE_ONEDNN_OPTS', '0')
+    os.environ.setdefault('HF_HUB_DISABLE_SYMLINKS_WARNING', '1')
+    os.environ.setdefault('NLTK_DATA', os.path.join(root, 'nltk_data'))
+    os.environ.setdefault('MPLCONFIGDIR', os.path.join(root, '.qelm_cache', 'matplotlib'))
+
+    if sys.stdout is None:
+        sys.stdout = open(os.devnull, 'w', encoding='utf-8')
+    if sys.stderr is None:
+        sys.stderr = open(os.devnull, 'w', encoding='utf-8')
+
+    tcl_data = os.path.join(root, '_tcl_data')
+    tk_data = os.path.join(root, '_tk_data')
+    if os.path.isdir(tcl_data):
+        os.environ['TCL_LIBRARY'] = tcl_data
+    if os.path.isdir(tk_data):
+        os.environ['TK_LIBRARY'] = tk_data
+
+    graphviz_bin = os.path.join(root, 'graphviz', 'bin')
+    if os.path.isdir(graphviz_bin):
+        os.environ['PATH'] = os.environ.get('PATH', '') + os.pathsep + graphviz_bin
+
+
+def _write_startup_error(show_dialog=True):
+    path = os.path.join(_app_dir(), 'qelm_startup_error.txt')
+    text = traceback.format_exc()
+    try:
+        with open(path, 'w', encoding='utf-8') as handle:
+            handle.write(text)
+    except Exception:
+        pass
+    if not show_dialog:
+        return
+    try:
+        from tkinter import messagebox
+        messagebox.showerror('QELM', 'QELM could not start. Details were saved to qelm_startup_error.txt.')
+    except Exception:
+        pass
+
+
+def main():
+    _prepare_runtime()
+    smoke_test = '--qelm_exe_smoke' in sys.argv
+    if smoke_test:
+        sys.argv.remove('--qelm_exe_smoke')
+    try:
+        import Qelm2
+        Qelm2._install_crash_logger()
+        if smoke_test:
+            root = Qelm2.tk.Tk()
+            Qelm2.QELM_GUI(root)
+            root.update_idletasks()
+            root.destroy()
+            with open(os.path.join(_app_dir(), 'qelm_exe_smoke.ok'), 'w', encoding='utf-8') as handle:
+                handle.write('ok')
+            return
+        Qelm2.main()
+    except SystemExit:
+        raise
+    except Exception:
+        _write_startup_error(show_dialog=not smoke_test)
+        raise
+
+
+if __name__ == '__main__':
+    multiprocessing.freeze_support()
+    main()

--- a/qelm_exe.py
+++ b/qelm_exe.py
@@ -6,38 +6,57 @@ import traceback
 
 def _app_dir():
     if getattr(sys, 'frozen', False):
-        return os.path.dirname(sys.executable)
+        return os.path.dirname(os.path.abspath(sys.executable))
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+def _resource_dir():
+    if getattr(sys, 'frozen', False):
+        return os.path.abspath(getattr(sys, '_MEIPASS', _app_dir()))
     return os.path.dirname(os.path.abspath(__file__))
 
 
 def _prepare_runtime():
-    root = _app_dir()
-    os.chdir(root)
+    app_root = _app_dir()
+    resource_root = _resource_dir()
+    os.chdir(resource_root)
+
     os.environ.setdefault('QELM_LAZY_NATIVE_IMPORTS', '1')
     os.environ.setdefault('TF_ENABLE_ONEDNN_OPTS', '0')
     os.environ.setdefault('HF_HUB_DISABLE_SYMLINKS_WARNING', '1')
-    os.environ.setdefault('NLTK_DATA', os.path.join(root, 'nltk_data'))
-    os.environ.setdefault('MPLCONFIGDIR', os.path.join(root, '.qelm_cache', 'matplotlib'))
+    os.environ.setdefault('QELM_BUNDLE_ROOT', resource_root)
+    os.environ.setdefault('NLTK_DATA', os.path.join(resource_root, 'nltk_data'))
+    os.environ.setdefault('MPLCONFIGDIR', os.path.join(app_root, '.qelm_cache', 'matplotlib'))
 
     if sys.stdout is None:
         sys.stdout = open(os.devnull, 'w', encoding='utf-8')
     if sys.stderr is None:
         sys.stderr = open(os.devnull, 'w', encoding='utf-8')
 
-    tcl_data = os.path.join(root, '_tcl_data')
-    tk_data = os.path.join(root, '_tk_data')
+    tcl_data = os.path.join(resource_root, '_tcl_data')
+    tk_data = os.path.join(resource_root, '_tk_data')
     if os.path.isdir(tcl_data):
         os.environ['TCL_LIBRARY'] = tcl_data
     if os.path.isdir(tk_data):
         os.environ['TK_LIBRARY'] = tk_data
 
-    graphviz_bin = os.path.join(root, 'graphviz', 'bin')
+    graphviz_bin = os.path.join(resource_root, 'graphviz', 'bin')
     if os.path.isdir(graphviz_bin):
         os.environ['PATH'] = os.environ.get('PATH', '') + os.pathsep + graphviz_bin
 
 
+def _output_path(name):
+    override = os.environ.get('QELM_OUTPUT_DIR', '').strip()
+    root = os.path.abspath(override) if override else _app_dir()
+    try:
+        os.makedirs(root, exist_ok=True)
+    except Exception:
+        root = os.path.expanduser('~')
+    return os.path.join(root, name)
+
+
 def _write_startup_error(show_dialog=True):
-    path = os.path.join(_app_dir(), 'qelm_startup_error.txt')
+    path = _output_path('qelm_startup_error.txt')
     text = traceback.format_exc()
     try:
         with open(path, 'w', encoding='utf-8') as handle:
@@ -48,7 +67,7 @@ def _write_startup_error(show_dialog=True):
         return
     try:
         from tkinter import messagebox
-        messagebox.showerror('QELM', 'QELM could not start. Details were saved to qelm_startup_error.txt.')
+        messagebox.showerror('QELM', f'QELM could not start. Details were saved to {path}.')
     except Exception:
         pass
 
@@ -60,13 +79,13 @@ def main():
         sys.argv.remove('--qelm_exe_smoke')
     try:
         import Qelm2
-        Qelm2._install_crash_logger()
+        Qelm2._install_crash_logger(_output_path('qelm_crashlog.txt'))
         if smoke_test:
             root = Qelm2.tk.Tk()
             Qelm2.QELM_GUI(root)
             root.update_idletasks()
             root.destroy()
-            with open(os.path.join(_app_dir(), 'qelm_exe_smoke.ok'), 'w', encoding='utf-8') as handle:
+            with open(_output_path('qelm_exe_smoke.ok'), 'w', encoding='utf-8') as handle:
                 handle.write('ok')
             return
         Qelm2.main()

--- a/tests/test_exe_command.py
+++ b/tests/test_exe_command.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+import Qelm2
+
+
+def test_python_command_for_source(monkeypatch):
+    monkeypatch.delattr(sys, 'frozen', raising=False)
+    command = Qelm2._qelm_python_command('--qelm_prep_tokens')
+    assert command[0] == sys.executable
+    assert os.path.basename(command[1]) == 'Qelm2.py'
+    assert command[2] == '--qelm_prep_tokens'
+
+
+def test_python_command_for_executable(monkeypatch):
+    monkeypatch.setattr(sys, 'frozen', True, raising=False)
+    command = Qelm2._qelm_python_command('--qelm_prep_tokens')
+    assert command == [sys.executable, '--qelm_prep_tokens']

--- a/tests/test_exe_command.py
+++ b/tests/test_exe_command.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import Qelm2
+import qelm_exe
 
 
 def test_python_command_for_source(monkeypatch):
@@ -16,3 +17,16 @@ def test_python_command_for_executable(monkeypatch):
     monkeypatch.setattr(sys, 'frozen', True, raising=False)
     command = Qelm2._qelm_python_command('--qelm_prep_tokens')
     assert command == [sys.executable, '--qelm_prep_tokens']
+
+
+def test_onefile_resource_directory(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, 'frozen', True, raising=False)
+    monkeypatch.setattr(sys, '_MEIPASS', str(tmp_path), raising=False)
+    assert qelm_exe._resource_dir() == os.path.abspath(str(tmp_path))
+
+
+def test_frozen_app_directory_is_executable_parent(monkeypatch, tmp_path):
+    executable = tmp_path / 'QELM.exe'
+    monkeypatch.setattr(sys, 'frozen', True, raising=False)
+    monkeypatch.setattr(sys, 'executable', str(executable))
+    assert qelm_exe._app_dir() == os.path.abspath(str(tmp_path))


### PR DESCRIPTION
Builds the repaired QELM trainer as one self-contained Windows x64 executable without changing the model architecture.

The build produces exactly one file: `QELM.exe`. There is no companion application folder, launcher BAT, or multipart package. The executable embeds the Python runtime, current QLM models, datasets, Qiskit, Aer, IBM Runtime, TensorFlow/Keras, NumPy/SciPy, NLTK resources, Matplotlib, Graphviz, Tcl/Tk, and the existing trainer interface.

Windows trust hardening:
- embeds verified publisher and product metadata for `R&D BioTech Alaska Inc.` and `QELM`
- embeds an `asInvoker` Windows application manifest with no elevation request
- adds a Microsoft Artifact Signing release path using GitHub OIDC
- SHA-256 Authenticode signing is RFC 3161 timestamped and independently verified with PowerShell and SignTool
- signed releases fail closed when the required Azure identity or Artifact Signing profile is missing
- unsigned pull-request artifacts are explicitly labeled `QELM-Unsigned-CI-Windows-x64`
- the final executable is scanned with current Microsoft Defender signatures before upload

Validation on Windows x64:
- both repository workflows pass
- 28 source tests pass
- PyInstaller produces exactly one `dist/QELM.exe` and no output directory
- Windows reports CompanyName `R&D BioTech Alaska Inc.`, ProductName `QELM`, and OriginalFilename `QELM.exe`
- the single EXE prepares a dataset successfully
- the single EXE constructs and closes the full QELM trainer window successfully
- Microsoft Defender reports no threats
- current unsigned CI build size: 522,777,680 bytes
- current unsigned CI SHA-256: `17abd65597434dddf5e736e4e29c8be0c3a1e476bcea654c83ca598faa0da8d1`

The signing stages are intentionally skipped on pull-request builds. A trusted public release is produced only by manually dispatching the workflow with `sign_release=true` after the Microsoft Artifact Signing identity, account, certificate profile, GitHub OIDC secrets, and repository variables have been configured.